### PR TITLE
Implement client-side auth flow

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,11 @@ import type { NextRequest } from "next/server";
 export function middleware(req: NextRequest) {
   const protectedPaths = ["/me"];
   if (protectedPaths.some(p => req.nextUrl.pathname.startsWith(p))) {
-    const token = req.cookies.get(process.env.JWT_COOKIE_NAME || "access_token");
+    const cookieName =
+      process.env.JWT_COOKIE_NAME ||
+      process.env.NEXT_PUBLIC_JWT_COOKIE_NAME ||
+      "access_token";
+    const token = req.cookies.get(cookieName)?.value;
     if (!token) {
       const url = new URL("/login", req.url);
       return NextResponse.redirect(url);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
-
-type ErrorResponse = {
-  error?: string;
-};
+import { login as authenticate } from "@/lib/auth";
 
 export default function LoginPage() {
   const [login, setLogin] = useState("admin@example.com");
   const [password, setPassword] = useState("Admin@123");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [err, setErr] = useState<string | undefined>();
+  const router = useRouter();
+
   const benefits = [
     {
       icon: "⚡",
@@ -36,21 +36,14 @@ export default function LoginPage() {
     setIsSubmitting(true);
 
     try {
-      const response = await fetch("/api/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ login, password }),
-      });
-
-      if (response.ok) {
-        window.location.href = "/me";
+      await authenticate(login, password);
+      router.push("/me");
+    } catch (error) {
+      if (error instanceof Error) {
+        setErr(error.message);
         return;
       }
-
-      const payload = (await response.json().catch(() => ({}))) as ErrorResponse;
-      setErr(payload.error || "Login failed");
-    } catch {
-      setErr("Unable to reach the authentication service.");
+      setErr("Login failed");
     } finally {
       setIsSubmitting(false);
     }

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { cookies } from "next/headers";
-import { fetchMe } from "@/lib/auth";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { getMe, logout } from "@/lib/auth";
 
 type Profile = Record<string, unknown>;
 
@@ -79,7 +82,9 @@ function SessionCard({ hasProfile }: SessionCardProps) {
         </span>
         <h2 className="text-2xl font-semibold text-white">Secure &amp; synced</h2>
         <p className="text-sm leading-6 text-slate-300">
-          You are currently viewing live data fetched from the authentication service. {hasProfile ? "Your profile is synced and ready for use across the dashboard." : "Once authenticated details are available, this panel will highlight key metadata about your session."}
+          You are currently viewing live data fetched from the authentication service. {hasProfile
+            ? "Your profile is synced and ready for use across the dashboard."
+            : "Once authenticated details are available, this panel will highlight key metadata about your session."}
         </p>
         <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-5">
           <div>
@@ -88,7 +93,7 @@ function SessionCard({ hasProfile }: SessionCardProps) {
           </div>
           <div className="grid gap-1 text-sm text-slate-300">
             <p>JWT secured session</p>
-            <p className="text-slate-400">Tokens are verified server-side before rendering this page.</p>
+            <p className="text-slate-400">Tokens are verified client-side before rendering this page.</p>
           </div>
         </div>
       </div>
@@ -96,21 +101,56 @@ function SessionCard({ hasProfile }: SessionCardProps) {
   );
 }
 
-export default async function MePage() {
-  const cookieStore = await cookies();
-  const cookieStr = cookieStore.toString();
-  let profile: Profile | null = null;
-  let error: string | undefined;
+export default function MePage() {
+  const router = useRouter();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-  try {
-    const result: unknown = await fetchMe(cookieStr);
-    if (result && typeof result === "object") {
-      profile = result as Profile;
-    } else {
-      profile = { value: result } as Profile;
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchProfile() {
+      try {
+        const result = await getMe<Profile>();
+        if (!isMounted) return;
+        setProfile(result ?? {});
+      } catch (cause) {
+        if (!isMounted) return;
+        const message = cause instanceof Error && cause.message ? cause.message : "Unauthorized";
+        setError(message);
+        router.replace("/login");
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
     }
-  } catch (cause) {
-    error = cause instanceof Error && cause.message ? cause.message : "Unauthorized";
+
+    fetchProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [router]);
+
+  const profileEntries = useMemo(() => (profile ? Object.entries(profile) : []), [profile]);
+  const hasProfile = profileEntries.length > 0;
+
+  const onLogout = async () => {
+    await logout();
+    router.replace("/login");
+  };
+
+  if (isLoading) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 py-16 text-slate-100">
+        <div className="space-y-4 text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Loading</p>
+          <p className="text-lg text-slate-300">Fetching your profile…</p>
+        </div>
+      </main>
+    );
   }
 
   if (error) {
@@ -135,24 +175,26 @@ export default async function MePage() {
     );
   }
 
-  const profileEntries = profile ? Object.entries(profile) : [];
-  const hasProfile = profileEntries.length > 0;
-
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-12">
         <header className="text-center sm:text-left">
           <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Account</p>
           <div className="mt-2 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-            <h1 className="text-4xl font-semibold tracking-tight text-white">Profile overview</h1>
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-900/50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">
-              Live fetch
-            </span>
+            <div>
+              <h1 className="text-4xl font-semibold tracking-tight text-white">Profile overview</h1>
+              <p className="mt-4 text-sm text-slate-400 sm:max-w-xl">
+                Review the information returned from the authentication service. These values refresh every visit, ensuring that what you
+                see mirrors what the backend trusts.
+              </p>
+            </div>
+            <button
+              onClick={onLogout}
+              className="inline-flex items-center justify-center rounded-full border border-white/10 bg-slate-900/60 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-white/20 hover:bg-slate-900/80"
+            >
+              Sign out
+            </button>
           </div>
-          <p className="mt-4 text-sm text-slate-400 sm:max-w-xl">
-            Review the information returned from the authentication service. These values refresh every visit, ensuring that what you
-            see mirrors what the backend trusts.
-          </p>
         </header>
 
         <section className="grid gap-8 lg:grid-cols-[1.4fr_0.9fr]">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,10 +1,242 @@
-export async function fetchMe(cookie?: string) {
-  const token = cookie?.split(`${process.env.JWT_COOKIE_NAME}=`)[1]?.split(";")[0];
-  if (!token) throw new Error("no token");
-  const r = await fetch(`${process.env.AUTH_SERVICE_URL}/v1/auth/me`, {
-    headers: { Authorization: `Bearer ${token}` },
+const AUTH_SERVICE_URL =
+  process.env.NEXT_PUBLIC_AUTH_SERVICE_URL ||
+  process.env.AUTH_SERVICE_URL ||
+  "http://localhost:8010";
+
+const ACCESS_TOKEN_KEY = "access_token";
+const REFRESH_TOKEN_KEY = "refresh_token";
+const ACCESS_COOKIE_NAME =
+  process.env.NEXT_PUBLIC_JWT_COOKIE_NAME ||
+  process.env.JWT_COOKIE_NAME ||
+  "access_token";
+const DEFAULT_TOKEN_MAX_AGE = 60 * 60 * 8; // 8 hours
+
+type LoginPayload = {
+  login: string;
+  password: string;
+};
+
+type AuthSuccessResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  [key: string]: unknown;
+};
+
+type ErrorResponse = {
+  error?: string;
+  message?: string;
+};
+
+function isAuthSuccessResponse(value: unknown): value is AuthSuccessResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).access_token === "string"
+  );
+}
+
+function getLocalStorage(): Storage | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function setCookie(name: string, value: string, maxAge: number) {
+  if (typeof document === "undefined") return;
+  const encodedValue = encodeURIComponent(value);
+  document.cookie = `${name}=${encodedValue}; path=/; max-age=${Math.max(
+    0,
+    Math.trunc(maxAge),
+  )}; sameSite=Lax`;
+}
+
+function deleteCookie(name: string) {
+  if (typeof document === "undefined") return;
+  document.cookie = `${name}=; path=/; max-age=0; sameSite=Lax`;
+}
+
+function readCookie(name: string): string | undefined {
+  if (typeof document === "undefined") return undefined;
+  const cookies = document.cookie ? document.cookie.split(";") : [];
+  for (const cookie of cookies) {
+    const [rawKey, ...rest] = cookie.trim().split("=");
+    if (rawKey === name) {
+      return decodeURIComponent(rest.join("="));
+    }
+  }
+  return undefined;
+}
+
+function persistTokens({
+  access_token,
+  refresh_token,
+  expires_in,
+}: AuthSuccessResponse) {
+  const storage = getLocalStorage();
+  if (storage) {
+    storage.setItem(ACCESS_TOKEN_KEY, access_token);
+    if (refresh_token) {
+      storage.setItem(REFRESH_TOKEN_KEY, refresh_token);
+    } else {
+      storage.removeItem(REFRESH_TOKEN_KEY);
+    }
+  }
+
+  setCookie(ACCESS_COOKIE_NAME, access_token, expires_in ?? DEFAULT_TOKEN_MAX_AGE);
+}
+
+function clearTokens() {
+  const storage = getLocalStorage();
+  if (storage) {
+    storage.removeItem(ACCESS_TOKEN_KEY);
+    storage.removeItem(REFRESH_TOKEN_KEY);
+  }
+  deleteCookie(ACCESS_COOKIE_NAME);
+}
+
+function getStoredAccessToken(): string | undefined {
+  const storage = getLocalStorage();
+  const token = storage?.getItem(ACCESS_TOKEN_KEY) || readCookie(ACCESS_COOKIE_NAME);
+  return token ?? undefined;
+}
+
+function getStoredRefreshToken(): string | undefined {
+  const storage = getLocalStorage();
+  const token = storage?.getItem(REFRESH_TOKEN_KEY);
+  return token ?? undefined;
+}
+
+async function refreshAccessToken(): Promise<string> {
+  const refreshToken = getStoredRefreshToken();
+  if (!refreshToken) {
+    clearTokens();
+    throw new Error("Session expired");
+  }
+
+  const response = await fetch(`${AUTH_SERVICE_URL}/v1/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  });
+
+  const payload: unknown = await response.json().catch(() => ({}));
+
+  if (!response.ok || !isAuthSuccessResponse(payload)) {
+    clearTokens();
+    const message =
+      (payload as ErrorResponse)?.error ||
+      (payload as ErrorResponse)?.message ||
+      "Session expired";
+    throw new Error(message);
+  }
+
+  persistTokens(payload);
+  return payload.access_token;
+}
+
+export async function login(loginId: string, password: string) {
+  const payload: LoginPayload = { login: loginId, password };
+  const response = await fetch(`${AUTH_SERVICE_URL}/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const data: unknown = await response.json().catch(() => ({}));
+
+  if (!response.ok || !isAuthSuccessResponse(data)) {
+    const message =
+      (data as ErrorResponse)?.error ||
+      (data as ErrorResponse)?.message ||
+      "Login failed";
+    throw new Error(message);
+  }
+
+  persistTokens(data);
+  return data;
+}
+
+export async function getMe<TProfile = unknown>(): Promise<TProfile> {
+  let accessToken = getStoredAccessToken();
+  if (!accessToken) {
+    throw new Error("Not authenticated");
+  }
+
+  const response = await fetch(`${AUTH_SERVICE_URL}/v1/auth/me`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",
   });
-  if (!r.ok) throw new Error("unauthorized");
-  return r.json();
+
+  if (response.ok) {
+    return (await response.json()) as TProfile;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    try {
+      accessToken = await refreshAccessToken();
+    } catch (error) {
+      throw error instanceof Error ? error : new Error("Session expired");
+    }
+
+    const retryResponse = await fetch(`${AUTH_SERVICE_URL}/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      cache: "no-store",
+    });
+
+    if (retryResponse.ok) {
+      return (await retryResponse.json()) as TProfile;
+    }
+
+    if (retryResponse.status === 401 || retryResponse.status === 403) {
+      clearTokens();
+      throw new Error("Unauthorized");
+    }
+
+    const retryError: unknown = await retryResponse.json().catch(() => ({}));
+    const retryMessage =
+      (retryError as ErrorResponse)?.error ||
+      (retryError as ErrorResponse)?.message ||
+      retryResponse.statusText ||
+      "Failed to fetch profile";
+    throw new Error(retryMessage);
+  }
+
+  const errorPayload: unknown = await response.json().catch(() => ({}));
+  const message =
+    (errorPayload as ErrorResponse)?.error ||
+    (errorPayload as ErrorResponse)?.message ||
+    response.statusText ||
+    "Failed to fetch profile";
+  throw new Error(message);
+}
+
+export async function logout() {
+  const accessToken = getStoredAccessToken();
+  try {
+    if (accessToken) {
+      await fetch(`${AUTH_SERVICE_URL}/v1/auth/logout`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+    }
+  } finally {
+    clearTokens();
+  }
+}
+
+export function getAccessToken() {
+  return getStoredAccessToken();
+}
+
+export function getRefreshToken() {
+  return getStoredRefreshToken();
 }


### PR DESCRIPTION
## Summary
- replace the auth library with helpers that manage tokens, refresh logic, and logout calls
- update the login experience to call the auth service directly and persist tokens before redirecting
- convert the profile page to a client component that fetches the session, handles refresh, and offers logout while tightening middleware checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d80f23e05483308b10e3655164a3c2